### PR TITLE
[feat] 게임 로비 픽셀아트 공간 추가

### DIFF
--- a/games/index.html
+++ b/games/index.html
@@ -1,0 +1,565 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>게임 로비</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body {
+    height: 100%;
+    background: #14101a;
+    color: #e8d8c8;
+    font-family: 'Courier New', monospace;
+    overflow: hidden;
+  }
+  body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+  }
+  #stage {
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
+    border: 4px solid #3a2a30;
+    box-shadow: 0 0 40px rgba(0,0,0,0.6), inset 0 0 0 2px #5a4a50;
+    max-width: 100%;
+  }
+  #hud {
+    font-size: 12px;
+    color: #aa9988;
+    letter-spacing: 1px;
+    text-align: center;
+    user-select: none;
+  }
+  #hud .key {
+    display: inline-block;
+    background: #3a2a30;
+    color: #ffdb70;
+    padding: 2px 8px;
+    border-radius: 2px;
+    margin: 0 2px;
+    border: 1px solid #5a4a50;
+  }
+  #hud .hint { color: #6a5a55; margin-left: 10px; }
+</style>
+</head>
+<body>
+  <canvas id="stage" width="320" height="192"></canvas>
+  <div id="hud">
+    이동 <span class="key">W A S D</span> <span class="key">← ↑ ↓ →</span>
+    <span class="hint">게임 테이블에 다가가면 이름이 떠요</span>
+  </div>
+
+<script>
+(() => {
+  const canvas = document.getElementById('stage');
+  const ctx = canvas.getContext('2d');
+  ctx.imageSmoothingEnabled = false;
+
+  const TILE = 16;
+  const COLS = 20;
+  const ROWS = 12;
+
+  const updateScale = () => {
+    const maxW = window.innerWidth - 16;
+    const maxH = window.innerHeight - 100;
+    const scale = Math.max(1, Math.floor(Math.min(maxW / canvas.width, maxH / canvas.height)));
+    canvas.style.width = (canvas.width * scale) + 'px';
+    canvas.style.height = (canvas.height * scale) + 'px';
+  };
+  updateScale();
+  window.addEventListener('resize', updateScale);
+
+  const C = {
+    wallDark:  '#241620',
+    wallMid:   '#4a2a38',
+    wallLite:  '#6a3a48',
+    floorDark: '#3a2a32',
+    floorMid:  '#4a3540',
+    floorLite: '#5a4550',
+    grout:     '#241820',
+    woodDark:  '#5a3a25',
+    woodMid:   '#7a5235',
+    woodLite:  '#9a6e45',
+    metal:     '#888888',
+    metalDark: '#4a4a52',
+    screen:    '#0a1428',
+    cyan:      '#3afaff',
+    yellow:    '#ffd840',
+    red:       '#e84050',
+    green:     '#40c060',
+    blue:      '#4060e0',
+    purple:    '#a050d0',
+    orange:    '#ff8030',
+    cloth:     '#1c5040',
+    clothEdge: '#0e2820',
+    paper:     '#f0e0c0',
+    paperEdge: '#c0a878',
+    ink:       '#1a1015',
+    skin:      '#f0c098',
+    hair:      '#3a2418',
+    shirt:     '#4080c8',
+    shirtHi:   '#60a0e0',
+    pants:     '#2a3548',
+    shoe:      '#1a1015',
+  };
+
+  const MAP = [
+    'WWWWWWWWWWWWWWWWWWWW',
+    'W..................W',
+    'W..SSS........TT...W',
+    'W..SSS........TT...W',
+    'W..................W',
+    'W..................W',
+    'W..................W',
+    'W..................W',
+    'W..RRRR....MMM.....W',
+    'W..RRRR....MMM.....W',
+    'W..................W',
+    'WWWWWWWWWWWWWWWWWWWW',
+  ];
+
+  const isSolid = (col, row) => {
+    if (col < 0 || row < 0 || col >= COLS || row >= ROWS) return true;
+    return MAP[row][col] !== '.';
+  };
+
+  const stations = [
+    { name: '스도쿠',   cx: (3 + 1.5) * TILE,  cy: 2 * TILE },
+    { name: '테트리스', cx: (14 + 1) * TILE,   cy: 2 * TILE },
+    { name: '루미큐브', cx: (3 + 2) * TILE,    cy: 8 * TILE },
+    { name: '마피아',   cx: (11 + 1.5) * TILE, cy: 8 * TILE },
+  ];
+
+  function drawFloor() {
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        if (MAP[r][c] === 'W') continue;
+        const x = c * TILE, y = r * TILE;
+        ctx.fillStyle = ((c + r) & 1) ? C.floorMid : C.floorDark;
+        ctx.fillRect(x, y, TILE, TILE);
+        ctx.fillStyle = C.grout;
+        ctx.fillRect(x, y + TILE - 1, TILE, 1);
+        ctx.fillRect(x + TILE - 1, y, 1, TILE);
+        ctx.fillStyle = C.floorLite;
+        ctx.fillRect(x + 2, y + 2, 1, 1);
+        ctx.fillRect(x + 9, y + 6, 1, 1);
+      }
+    }
+  }
+
+  function drawWalls() {
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        if (MAP[r][c] !== 'W') continue;
+        const x = c * TILE, y = r * TILE;
+        ctx.fillStyle = C.wallMid;
+        ctx.fillRect(x, y, TILE, TILE);
+        ctx.fillStyle = C.wallDark;
+        ctx.fillRect(x, y + 7, TILE, 1);
+        ctx.fillRect(x, y + 15, TILE, 1);
+        const off = (r % 2) * 8;
+        ctx.fillRect(x + off, y, 1, 8);
+        ctx.fillRect(x + ((off + 8) % TILE), y + 8, 1, 8);
+        ctx.fillStyle = C.wallLite;
+        ctx.fillRect(x + 2, y + 1, 4, 1);
+        ctx.fillRect(x + 10, y + 9, 4, 1);
+      }
+    }
+  }
+
+  function drawSudokuTable() {
+    const x = 3 * TILE, y = 2 * TILE, w = 3 * TILE, h = 2 * TILE;
+    ctx.fillStyle = 'rgba(0,0,0,0.4)';
+    ctx.fillRect(x + 2, y + h, w, 3);
+    ctx.fillStyle = C.woodDark;
+    ctx.fillRect(x, y, w, h);
+    ctx.fillStyle = C.woodMid;
+    ctx.fillRect(x + 1, y + 1, w - 2, h - 3);
+    ctx.fillStyle = C.woodLite;
+    ctx.fillRect(x + 1, y + 1, w - 2, 1);
+    // sudoku paper
+    const gx = x + 8, gy = y + 4, gs = 32;
+    ctx.fillStyle = C.paperEdge;
+    ctx.fillRect(gx - 1, gy - 1, gs + 2, gs + 2);
+    ctx.fillStyle = C.paper;
+    ctx.fillRect(gx, gy, gs, gs);
+    // 3x3 grid lines
+    ctx.fillStyle = C.ink;
+    for (let i = 0; i <= 3; i++) {
+      const p = Math.round(i * gs / 3);
+      ctx.fillRect(gx + p, gy, 1, gs + 1);
+      ctx.fillRect(gx, gy + p, gs + 1, 1);
+    }
+    // a few numbers (dots)
+    const nums = [[1,1,C.blue],[2,0,C.red],[0,2,C.green],[2,2,C.blue]];
+    nums.forEach(([cx, cy, col]) => {
+      ctx.fillStyle = col;
+      const px = gx + cx * 11 + 4;
+      const py = gy + cy * 11 + 4;
+      ctx.fillRect(px, py, 3, 4);
+    });
+  }
+
+  function drawTetrisCabinet() {
+    const x = 14 * TILE, y = 2 * TILE, w = 2 * TILE, h = 2 * TILE;
+    ctx.fillStyle = 'rgba(0,0,0,0.4)';
+    ctx.fillRect(x + 2, y + h, w, 3);
+    // cabinet body
+    ctx.fillStyle = C.metalDark;
+    ctx.fillRect(x + 2, y, w - 4, h);
+    ctx.fillStyle = C.metal;
+    ctx.fillRect(x + 3, y + 1, w - 6, h - 2);
+    // marquee
+    ctx.fillStyle = C.red;
+    ctx.fillRect(x + 4, y + 1, w - 8, 3);
+    ctx.fillStyle = C.yellow;
+    ctx.fillRect(x + 6, y + 2, 2, 1);
+    ctx.fillRect(x + 10, y + 2, 2, 1);
+    ctx.fillRect(x + 14, y + 2, 2, 1);
+    ctx.fillRect(x + 18, y + 2, 2, 1);
+    // screen
+    const sx = x + 6, sy = y + 6, sw = w - 12, sh = 14;
+    ctx.fillStyle = '#000';
+    ctx.fillRect(sx - 1, sy - 1, sw + 2, sh + 2);
+    ctx.fillStyle = C.screen;
+    ctx.fillRect(sx, sy, sw, sh);
+    // animated falling pieces
+    const t = performance.now() / 200 | 0;
+    const piece = (t % 4);
+    const dropY = (t % 6);
+    const blocks = [
+      [C.cyan,   2,  sh - 4, 4, 2],
+      [C.yellow, 6,  sh - 4, 4, 4],
+      [C.red,    10, sh - 4, 4, 2],
+      [C.green,  14, sh - 6, 2, 2],
+      [C.purple, 4,  sh - 8, 2, 2],
+    ];
+    blocks.forEach(([col, bx, by, bw, bh]) => {
+      ctx.fillStyle = col;
+      ctx.fillRect(sx + bx, sy + by, bw, bh);
+    });
+    // falling piece
+    ctx.fillStyle = [C.cyan, C.yellow, C.red, C.purple][piece];
+    ctx.fillRect(sx + 8, sy + dropY, 4, 2);
+    // control panel
+    ctx.fillStyle = C.wallDark;
+    ctx.fillRect(x + 4, y + h - 6, w - 8, 4);
+    ctx.fillStyle = C.red;
+    ctx.fillRect(x + 7, y + h - 5, 2, 2);
+    ctx.fillStyle = C.cyan;
+    ctx.fillRect(x + 13, y + h - 5, 2, 2);
+    ctx.fillStyle = C.yellow;
+    ctx.fillRect(x + 19, y + h - 5, 2, 2);
+  }
+
+  function drawRummikubTable() {
+    const x = 3 * TILE, y = 8 * TILE, w = 4 * TILE, h = 2 * TILE;
+    ctx.fillStyle = 'rgba(0,0,0,0.4)';
+    ctx.fillRect(x + 2, y + h, w, 3);
+    ctx.fillStyle = C.clothEdge;
+    ctx.fillRect(x, y, w, h);
+    ctx.fillStyle = C.cloth;
+    ctx.fillRect(x + 1, y + 1, w - 2, h - 3);
+    // tile rows
+    const tileColors = [C.red, C.blue, C.yellow, C.orange];
+    for (let i = 0; i < 11; i++) {
+      const tx = x + 4 + i * 5;
+      const ty = y + 5;
+      ctx.fillStyle = C.paper;
+      ctx.fillRect(tx, ty, 4, 6);
+      ctx.fillStyle = C.paperEdge;
+      ctx.fillRect(tx, ty + 5, 4, 1);
+      ctx.fillStyle = tileColors[i % 4];
+      ctx.fillRect(tx + 1, ty + 1, 2, 1);
+      ctx.fillRect(tx + 1, ty + 3, 2, 1);
+    }
+    for (let i = 0; i < 9; i++) {
+      const tx = x + 8 + i * 5;
+      const ty = y + 14;
+      ctx.fillStyle = C.paper;
+      ctx.fillRect(tx, ty, 4, 6);
+      ctx.fillStyle = C.paperEdge;
+      ctx.fillRect(tx, ty + 5, 4, 1);
+      ctx.fillStyle = tileColors[(i + 2) % 4];
+      ctx.fillRect(tx + 1, ty + 2, 2, 2);
+    }
+  }
+
+  function drawEllipse(cx, cy, rx, ry) {
+    for (let dy = -Math.ceil(ry); dy <= Math.ceil(ry); dy++) {
+      const wd = Math.round(rx * Math.sqrt(Math.max(0, 1 - (dy * dy) / (ry * ry))));
+      ctx.fillRect(Math.round(cx - wd), Math.round(cy + dy), wd * 2, 1);
+    }
+  }
+
+  function drawMafiaTable() {
+    const x = 11 * TILE, y = 8 * TILE, w = 3 * TILE, h = 2 * TILE;
+    const cx = x + w / 2, cy = y + h / 2;
+    ctx.fillStyle = 'rgba(0,0,0,0.4)';
+    drawEllipse(cx + 1, y + h + 1, w / 2 - 1, 3);
+    ctx.fillStyle = C.clothEdge;
+    drawEllipse(cx, cy, w / 2 - 1, h / 2);
+    ctx.fillStyle = '#3a1c22';
+    drawEllipse(cx, cy - 1, w / 2 - 3, h / 2 - 1);
+    // cards around
+    const cards = [
+      [cx - 18, cy - 3], [cx + 14, cy - 3],
+      [cx - 18, cy + 3], [cx + 14, cy + 3],
+    ];
+    cards.forEach(([px, py]) => {
+      ctx.fillStyle = C.ink;
+      ctx.fillRect(px, py, 5, 4);
+      ctx.fillStyle = C.red;
+      ctx.fillRect(px + 1, py + 1, 3, 2);
+    });
+    // candle in middle - flickering
+    const flick = (Math.sin(performance.now() / 80) + Math.sin(performance.now() / 47)) * 0.5;
+    ctx.fillStyle = C.paperEdge;
+    ctx.fillRect(Math.round(cx) - 1, Math.round(cy) - 3, 2, 5);
+    ctx.fillStyle = C.orange;
+    ctx.fillRect(Math.round(cx) - 1, Math.round(cy) - 6 + (flick > 0 ? 0 : -1), 2, 3);
+    ctx.fillStyle = C.yellow;
+    ctx.fillRect(Math.round(cx) - 1, Math.round(cy) - 5 + (flick > 0 ? 0 : -1), 2, 1);
+    // light glow
+    ctx.fillStyle = 'rgba(255,200,80,0.08)';
+    drawEllipse(cx, cy, 24 + flick, 14 + flick);
+  }
+
+  // ===== Player =====
+  const player = {
+    x: 10 * TILE - 5,
+    y: 6 * TILE - 6,
+    w: 10,
+    h: 12,
+    speed: 1.3,
+    dir: 0,
+    frame: 0,
+    moving: false,
+    animTimer: 0,
+  };
+
+  function drawPlayer() {
+    const px = Math.round(player.x);
+    const py = Math.round(player.y);
+    ctx.fillStyle = 'rgba(0,0,0,0.35)';
+    ctx.fillRect(px - 1, py + player.h - 1, player.w + 2, 2);
+
+    const bob = (player.moving && player.frame === 1) ? -1 : 0;
+
+    // legs
+    ctx.fillStyle = C.pants;
+    if (player.moving && player.frame === 0) {
+      ctx.fillRect(px + 1, py + 8, 3, 4);
+      ctx.fillRect(px + 6, py + 8, 3, 3);
+    } else if (player.moving && player.frame === 1) {
+      ctx.fillRect(px + 1, py + 8, 3, 3);
+      ctx.fillRect(px + 6, py + 8, 3, 4);
+    } else {
+      ctx.fillRect(px + 1, py + 8, 3, 4);
+      ctx.fillRect(px + 6, py + 8, 3, 4);
+    }
+    // shoes
+    ctx.fillStyle = C.shoe;
+    const lShoeY = (player.moving && player.frame === 1) ? py + 10 : py + 11;
+    const rShoeY = (player.moving && player.frame === 0) ? py + 10 : py + 11;
+    ctx.fillRect(px + 1, lShoeY, 3, 1);
+    ctx.fillRect(px + 6, rShoeY, 3, 1);
+
+    // body
+    ctx.fillStyle = C.shirt;
+    ctx.fillRect(px + 1, py + 4 + bob, 8, 5);
+    ctx.fillRect(px, py + 5 + bob, 1, 3);
+    ctx.fillRect(px + 9, py + 5 + bob, 1, 3);
+    ctx.fillStyle = C.shirtHi;
+    ctx.fillRect(px + 1, py + 4 + bob, 8, 1);
+
+    // head
+    ctx.fillStyle = C.skin;
+    ctx.fillRect(px + 2, py + bob, 6, 5);
+    // hair
+    ctx.fillStyle = C.hair;
+    ctx.fillRect(px + 2, py + bob, 6, 2);
+    ctx.fillRect(px + 1, py + 1 + bob, 1, 2);
+    ctx.fillRect(px + 8, py + 1 + bob, 1, 2);
+
+    // face by direction
+    ctx.fillStyle = C.ink;
+    if (player.dir === 0) {
+      ctx.fillRect(px + 3, py + 3 + bob, 1, 1);
+      ctx.fillRect(px + 6, py + 3 + bob, 1, 1);
+    } else if (player.dir === 1) {
+      ctx.fillStyle = C.hair;
+      ctx.fillRect(px + 2, py + 2 + bob, 6, 1);
+    } else if (player.dir === 2) {
+      ctx.fillRect(px + 3, py + 3 + bob, 1, 1);
+    } else {
+      ctx.fillRect(px + 6, py + 3 + bob, 1, 1);
+    }
+  }
+
+  // ===== Input =====
+  const keys = {};
+  window.addEventListener('keydown', (e) => {
+    const k = e.key.toLowerCase();
+    keys[k] = true;
+    if (['arrowup','arrowdown','arrowleft','arrowright',' '].includes(k)) {
+      e.preventDefault();
+    }
+  });
+  window.addEventListener('keyup', (e) => {
+    keys[e.key.toLowerCase()] = false;
+  });
+  window.addEventListener('blur', () => { for (const k in keys) keys[k] = false; });
+
+  function canMoveTo(nx, ny) {
+    const corners = [
+      [nx, ny],
+      [nx + player.w - 1, ny],
+      [nx, ny + player.h - 1],
+      [nx + player.w - 1, ny + player.h - 1],
+    ];
+    return corners.every(([x, y]) => !isSolid(Math.floor(x / TILE), Math.floor(y / TILE)));
+  }
+
+  function updatePlayer(dt) {
+    let dx = 0, dy = 0;
+    if (keys['w'] || keys['arrowup']) dy -= 1;
+    if (keys['s'] || keys['arrowdown']) dy += 1;
+    if (keys['a'] || keys['arrowleft']) dx -= 1;
+    if (keys['d'] || keys['arrowright']) dx += 1;
+
+    player.moving = (dx !== 0 || dy !== 0);
+
+    if (dx !== 0 && dy !== 0) {
+      dx *= 0.7071;
+      dy *= 0.7071;
+    }
+
+    if (dy < 0) player.dir = 1;
+    else if (dy > 0) player.dir = 0;
+    if (dx < 0) player.dir = 2;
+    else if (dx > 0) player.dir = 3;
+
+    const step = player.speed * (dt / 16.667);
+    const nx = player.x + dx * step;
+    const ny = player.y + dy * step;
+
+    if (canMoveTo(nx, player.y)) player.x = nx;
+    if (canMoveTo(player.x, ny)) player.y = ny;
+
+    if (player.moving) {
+      player.animTimer += dt;
+      if (player.animTimer > 160) {
+        player.animTimer = 0;
+        player.frame = (player.frame + 1) % 2;
+      }
+    } else {
+      player.frame = 0;
+      player.animTimer = 0;
+    }
+  }
+
+  function drawText(text, x, y, color, shadow) {
+    ctx.font = '8px monospace';
+    ctx.textBaseline = 'top';
+    if (shadow) {
+      ctx.fillStyle = shadow;
+      ctx.fillText(text, x + 1, y + 1);
+    }
+    ctx.fillStyle = color;
+    ctx.fillText(text, x, y);
+  }
+
+  function drawLabels() {
+    for (const s of stations) {
+      const dx = s.cx - (player.x + player.w / 2);
+      const dy = s.cy - (player.y + player.h / 2);
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist < 56) {
+        const label = s.name;
+        const tw = label.length * 7 + 8;
+        const lx = Math.round(s.cx - tw / 2);
+        const ly = Math.round(s.cy - 18);
+        ctx.fillStyle = 'rgba(0,0,0,0.85)';
+        ctx.fillRect(lx, ly, tw, 12);
+        ctx.fillStyle = '#ffdb70';
+        ctx.fillRect(lx, ly, tw, 1);
+        ctx.fillRect(lx, ly + 11, tw, 1);
+        ctx.fillRect(lx, ly, 1, 12);
+        ctx.fillRect(lx + tw - 1, ly, 1, 12);
+        drawText(label, lx + 4, ly + 2, '#ffdb70', '#000');
+      }
+    }
+  }
+
+  function drawDecor() {
+    // wall sconces along top
+    for (let c = 4; c < COLS - 3; c += 5) {
+      const x = c * TILE + 4;
+      const y = 1 * TILE - 3;
+      ctx.fillStyle = C.metalDark;
+      ctx.fillRect(x + 3, y, 2, 4);
+      // glow
+      ctx.fillStyle = 'rgba(255,200,80,0.12)';
+      drawEllipse(x + 4, y + 4, 8, 6);
+      ctx.fillStyle = '#ffd060';
+      ctx.fillRect(x + 2, y + 3, 4, 3);
+      ctx.fillStyle = '#fff0a0';
+      ctx.fillRect(x + 3, y + 4, 2, 1);
+    }
+    // rug under spawn
+    const rx = 9 * TILE, ry = 5 * TILE;
+    const rw = 3 * TILE, rh = 2 * TILE;
+    ctx.fillStyle = '#5a2030';
+    ctx.fillRect(rx, ry, rw, rh);
+    ctx.fillStyle = '#7a3050';
+    ctx.fillRect(rx + 2, ry + 2, rw - 4, rh - 4);
+    ctx.fillStyle = '#5a2030';
+    ctx.fillRect(rx + 6, ry + 4, 2, 2);
+    ctx.fillRect(rx + rw - 8, ry + 4, 2, 2);
+    ctx.fillRect(rx + 6, ry + rh - 6, 2, 2);
+    ctx.fillRect(rx + rw - 8, ry + rh - 6, 2, 2);
+    ctx.fillStyle = '#3a1020';
+    ctx.fillRect(rx + rw / 2 - 1, ry + rh / 2 - 1, 2, 2);
+  }
+
+  function drawVignette() {
+    const g = ctx.createRadialGradient(160, 96, 60, 160, 96, 200);
+    g.addColorStop(0, 'rgba(0,0,0,0)');
+    g.addColorStop(1, 'rgba(0,0,0,0.5)');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  }
+
+  let lastT = performance.now();
+  function loop(t) {
+    const dt = Math.min(50, t - lastT);
+    lastT = t;
+
+    updatePlayer(dt);
+
+    ctx.fillStyle = C.wallDark;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    drawFloor();
+    drawWalls();
+    drawDecor();
+    drawSudokuTable();
+    drawTetrisCabinet();
+    drawRummikubTable();
+    drawMafiaTable();
+    drawPlayer();
+    drawVignette();
+    drawLabels();
+
+    requestAnimationFrame(loop);
+  }
+  requestAnimationFrame(loop);
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
스도쿠·테트리스·루미큐브·마피아 4개 게임 테이블이 배치된
탑다운 픽셀아트 로비를 /games/ 에 구성. 캐릭터를 WASD/방향키로
움직이며 테이블에 다가가면 게임 이름 라벨이 표시됨.

- Canvas로 모든 스프라이트를 절차적으로 그려 외부 이미지·CDN 의존 0
- 16px 타일 기반 20x12 그리드 맵, AABB 충돌 처리
- 테트리스 화면·마피아 촛불 등 미세 애니메이션 포함
